### PR TITLE
Update NPM Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphQL Server for Express, Connect, Hapi and Koa
 
-[![npm version](https://badge.fury.io/js/graphql-server.svg)](https://badge.fury.io/js/graphql-server)
+[![npm version](https://badge.fury.io/js/graphql-server-core.svg)](https://badge.fury.io/js/graphql-server-core)
 [![Build Status](https://travis-ci.org/apollostack/graphql-server.svg?branch=master)](https://travis-ci.org/apollostack/graphql-server)
 [![Coverage Status](https://coveralls.io/repos/github/apollostack/graphql-server/badge.svg?branch=master)](https://coveralls.io/github/apollostack/graphql-server?branch=master)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollostack.com/#slack)


### PR DESCRIPTION
Just seen that NPM badge is for the old package.
since this is built from couple of packages, i think it makes sense to point it to core...