### PR TITLE
Allow to install graphql@0.8

### DIFF
--- a/packages/graphql-server-core/package.json
+++ b/packages/graphql-server-core/package.json
@@ -31,7 +31,7 @@
     "meteor-promise": "^0.7.3"
   },
   "peerDependencies": {
-    "graphql": "^0.6.1 || ^0.7.0"
+    "graphql": "^0.6.1 || ^0.7.0 || ^0.8.0"
   },
   "optionalDependencies": {
     "typed-graphql": "^1.0.2"

--- a/packages/graphql-server-express/package.json
+++ b/packages/graphql-server-express/package.json
@@ -42,7 +42,7 @@
     "typed-graphql": "^1.0.2"
   },
   "peerDependencies": {
-    "graphql": "^0.6.1 || ^0.7.0"
+    "graphql": "^0.6.1 || ^0.7.0 || ^0.8.0"
   },
   "optionalDependencies": {
     "@types/express": "^4.0.33"

--- a/packages/graphql-server-hapi/package.json
+++ b/packages/graphql-server-hapi/package.json
@@ -37,7 +37,7 @@
     "typed-graphql": "^1.0.2"
   },
   "peerDependencies": {
-    "graphql": "^0.6.1 || ^0.7.0"
+    "graphql": "^0.6.1 || ^0.7.0 || ^0.8.0"
   },
   "optionalDependencies": {
     "@types/hapi": "^13.0.35",

--- a/packages/graphql-server-integration-testsuite/package.json
+++ b/packages/graphql-server-integration-testsuite/package.json
@@ -30,7 +30,7 @@
     "typed-graphql": "^1.0.2"
   },
   "peerDependencies": {
-    "graphql": "^0.6.1 || ^0.7.0"
+    "graphql": "^0.6.1 || ^0.7.0 || ^0.8.0"
   },
   "optionalDependencies": {
     "typed-graphql": "^1.0.2"

--- a/packages/graphql-server-koa/package.json
+++ b/packages/graphql-server-koa/package.json
@@ -39,7 +39,7 @@
     "typed-graphql": "^1.0.2"
   },
   "peerDependencies": {
-    "graphql": "^0.6.1 || ^0.7.0"
+    "graphql": "^0.6.1 || ^0.7.0 || ^0.8.0"
   },
   "optionalDependencies": {
     "@types/koa": "^2.0.33",

--- a/packages/graphql-server-module-operation-store/package.json
+++ b/packages/graphql-server-module-operation-store/package.json
@@ -28,7 +28,7 @@
     "typed-graphql": "^1.0.2"
   },
   "peerDependencies": {
-    "graphql": "^0.6.1 || ^0.7.0"
+    "graphql": "^0.6.1 || ^0.7.0 || ^0.8.0"
   },
   "optionalDependencies": {
     "typed-graphql": "^1.0.2"


### PR DESCRIPTION
Fixes #234
Changelog already has "Upgrade to GraphQL-js 0.8.1.".