### PR TITLE
Restify: Fix for calling next()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### VNEXT
 
-* ...
+* Restify: Fix for calling next() (([@jadkap](https://github.com/jadkap)) on [#285](https://github.com/apollostack/graphql-server/pull/285))
 
 ### v0.5.2
 * **Restify integration** ([@joelgriffith](https://github.com/joelgriffith)) on [#189](https://github.com/apollostack/graphql-server/pull/189)

--- a/packages/graphql-server-restify/src/restifyApollo.ts
+++ b/packages/graphql-server-restify/src/restifyApollo.ts
@@ -13,7 +13,7 @@ export interface RestifyGraphQLOptionsFunction {
 //
 
 export interface RestifyHandler {
-  (req: restify.Request, res: restify.Response, next): void;
+  (req: restify.Request, res: restify.Response, next: restify.Next): void;
 }
 
 export function graphqlRestify(options: GraphQLOptions | RestifyGraphQLOptionsFunction): RestifyHandler {
@@ -25,7 +25,7 @@ export function graphqlRestify(options: GraphQLOptions | RestifyGraphQLOptionsFu
     throw new Error(`Apollo Server expects exactly one argument, got ${arguments.length}`);
   }
 
-  return (req: restify.Request, res: restify.Response, next): void => {
+  return (req: restify.Request, res: restify.Response, next: restify.Next): void => {
     runHttpQuery([req, res], {
       method: req.method,
       options: options,
@@ -34,6 +34,7 @@ export function graphqlRestify(options: GraphQLOptions | RestifyGraphQLOptionsFu
       res.setHeader('Content-Type', 'application/json');
       res.write(gqlResponse);
       res.end();
+      next();
     }, (error: HttpQueryError) => {
       if ( 'HttpQueryError' !== error.name ) {
         throw error;
@@ -48,6 +49,7 @@ export function graphqlRestify(options: GraphQLOptions | RestifyGraphQLOptionsFu
       res.statusCode = error.statusCode;
       res.write(error.message);
       res.end();
+      next(false);
     });
   };
 }
@@ -64,7 +66,7 @@ export function graphqlRestify(options: GraphQLOptions | RestifyGraphQLOptionsFu
  */
 
 export function graphiqlRestify(options: GraphiQL.GraphiQLData) {
-  return (req: restify.Request, res: restify.Response, next) => {
+  return (req: restify.Request, res: restify.Response, next: restify.Next) => {
     const q = req.url && url.parse(req.url, true).query || {};
     const query = q.query || '';
     const operationName = q.operationName || '';
@@ -79,5 +81,6 @@ export function graphiqlRestify(options: GraphiQL.GraphiQLData) {
     res.setHeader('Content-Type', 'text/html');
     res.write(graphiQLString);
     res.end();
+    next();
   };
 }


### PR DESCRIPTION
Follow up to https://github.com/apollostack/graphql-server/pull/189

- Added next() calls and type annotation for restify.Next.  In order for restify’s "after" event to fire (like triggering a call to auditLogger), next() needs to be called after sending a response. From http://restify.com/#routing: "Note the use of next(). You are responsible for calling next() in order to run the next handler in the chain."

- I also discovered something with Restify’s bodyParser that results in an inconsistent response in a particular scenario vs. Koa and Express (didn’t check Hapi).  Restify’s bodyParser returns undefined (vs. Express & Koa returning {}) if body parser is used but no request body is sent.  This test https://github.com/apollostack/graphql-server/blob/master/packages/graphql-server-integration-testsuite/src/index.ts#L212-L221) passes because it’s not specifying any body parser, so all server variants return undefined.  What’s happening is that in the case of Restify, if you use bodyParser, but don't send body, GraphQL is responding with 500 ‘POST body missing. Did you forget use body-parser middleware?’ whereas the same scenario in Koa and Express variants return 400 "Cannot read property 'definitions' of undefined" in nested error response. I started fixing it in the graphql restify code, but then that breaks the above test for Restify.  Workaround is to either add validation middleware before calling graphqlRestify() or add a server.pre() handler to convert the body to {} if it’s undefined and content-type is application/json.
